### PR TITLE
Fixed room changing bug and added enemy respawn when changing room size

### DIFF
--- a/Assets/Prefabs/Room.prefab
+++ b/Assets/Prefabs/Room.prefab
@@ -13425,7 +13425,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &5581982203018302187
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Rooms/Room.cs
+++ b/Assets/Scripts/Rooms/Room.cs
@@ -33,7 +33,12 @@ namespace Rooms
 
         private void OnTriggerEnter2D(Collider2D col)
         {
-            RoomManager.ChangeRoom(Node);
+            RoomManager.EnteredRoom(Node);
+        }
+        
+        private void OnTriggerExit2D(Collider2D col)
+        {
+            RoomManager.ExitedRoom(Node);
         }
 
         #endregion

--- a/Assets/Scripts/Rooms/RoomUnityEditor.cs
+++ b/Assets/Scripts/Rooms/RoomUnityEditor.cs
@@ -66,9 +66,11 @@ namespace Rooms
                             tilemap.SetTile(pos, properties.GateTile);
                             continue;
                         }
+
                         tilemap.SetTile(pos, properties.WallTile);
                         continue;
                     }
+
                     tilemap.SetTile(pos, properties.GroundTile);
                 }
         }


### PR DESCRIPTION
When entering a new room collider, it's reference is now stored and only when exiting the current room collider the camera switches.